### PR TITLE
Operation id validation

### DIFF
--- a/swagger_react_admin_generator/generator.py
+++ b/swagger_react_admin_generator/generator.py
@@ -754,7 +754,7 @@ class Generator(object):
         """
         full_dir = f"{self.output_dir}/{_dir_name}"
         if _dir_name not in self._directories:
-            os.makedirs(full_dir)
+            os.makedirs(full_dir, exist_ok=True)
             self._directories.add(_dir_name)
         return full_dir
 

--- a/swagger_react_admin_generator/generator.py
+++ b/swagger_react_admin_generator/generator.py
@@ -613,7 +613,16 @@ class Generator(object):
                     if not operation_id or not valid_operation or exclude:
                         continue
 
-                singular, op = operation_id.rsplit("_", 1)
+                try:
+                    singular, op = operation_id.rsplit("_", 1)
+                except ValueError:
+                    click.secho(f"Skipping malformed operation_id '{operation_id}'.", fg="red")
+                    click.secho("It needs to have the form '<singular_resource_name>_<operation>',"
+                                " where operation is one of: {}".format(
+                                    ', '.join(VALID_OPERATIONS.keys())
+                                ), fg="red")
+                    continue
+
                 plural = path[1:].split("/")[0]
                 details = VALID_OPERATIONS.get(op, None)
                 if details:
@@ -903,7 +912,8 @@ class Generator(object):
 @click.argument("specification_path", type=click.Path(dir_okay=False, exists=True))
 @click.option("--spec-format", type=click.Choice(SPEC_CHOICES))
 @click.option("--verbose/--not-verbose", default=False)
-@click.option("--output-dir", type=click.Path(file_okay=False, exists=True, writable=True))
+@click.option("--output-dir", type=click.Path(file_okay=False, exists=True, writable=True),
+              default=DEFAULT_OUTPUT_DIR)
 @click.option("--module-name", type=str, default=DEFAULT_MODULE,
               help="The name of the module where the generated code will be "
                    "used, e.g. myproject.some_application")


### PR DESCRIPTION
# Background

Specs with `operationId` values that do not conform to the requirements of this tool, would fail in a manner that was not user friendly at all.

# What was done.

Some validation is performed on the `operationId` field. Non-conforming `operationId`s will be skipped and therefor not lead to any code generation. This is visible in the output generated by the tool, e.g.
```
Skipping malformed operation_id 'createUsersWithArrayInput'.
It needs to have the form '<singular_resource_name>_<operation>', where operation is one of: list, read, create, update, delete
```

Some other minor usability issue were also addressed. The default output directory has been added to the application parameter as a  default and when directories already exists, the directory creation does not cause a failure anymore.